### PR TITLE
Verify compatibility with WordPress 7.1

### DIFF
--- a/.github/scripts/resolve-wordpress-ref.sh
+++ b/.github/scripts/resolve-wordpress-ref.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+WP_VERSION="${1:?Usage: resolve-wordpress-ref.sh <version>}"
+WORDPRESS_REPOSITORY="https://github.com/WordPress/WordPress"
+LOOKUP_TIMEOUT="30s"
+GIT_COMMAND="${GIT_COMMAND:-git}"
+
+if [ "${WP_VERSION}" = "6.4" ]; then
+	printf '%s\n' "${WP_VERSION}"
+	exit 0
+fi
+
+if ! TAG_RESULT=$(timeout "${LOOKUP_TIMEOUT}" "${GIT_COMMAND}" ls-remote --tags "${WORDPRESS_REPOSITORY}" "refs/tags/${WP_VERSION}"); then
+	echo "::error::Unable to query the WordPress ${WP_VERSION} tag" >&2
+	exit 1
+fi
+if [ -n "${TAG_RESULT}" ]; then
+	printf '%s\n' "${WP_VERSION}"
+	exit 0
+fi
+
+WP_BRANCH="${WP_VERSION}-branch"
+if ! BRANCH_RESULT=$(timeout "${LOOKUP_TIMEOUT}" "${GIT_COMMAND}" ls-remote --heads "${WORDPRESS_REPOSITORY}" "refs/heads/${WP_BRANCH}"); then
+	echo "::error::Unable to query the WordPress ${WP_BRANCH} release branch" >&2
+	exit 1
+fi
+if [ -n "${BRANCH_RESULT}" ]; then
+	echo "::notice::WordPress tag ${WP_VERSION} not found — using release branch ${WP_BRANCH}" >&2
+	printf '%s\n' "${WP_BRANCH}"
+	exit 0
+fi
+
+echo "::warning::WordPress tag and release branch for ${WP_VERSION} not found — falling back to trunk" >&2
+printf 'trunk\n'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,7 +379,7 @@ jobs:
           WP_ADMIN_USER: admin
           WP_ADMIN_PASS: password
         run: |
-          if [ "${WP_VERSION}" = "6.4" ]; then
+          if [ "${{ github.event_name }}" != "pull_request" ] && [ "${WP_VERSION}" = "6.4" ]; then
             npm run test:e2e
           else
             npm run test:e2e -- --grep "@compat"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
 
 ##############################################################################
 # TIER 2 — standard (Playwright E2E via @wordpress/env, target <12 min)
-# Runs on: push or PR targeting main or development branches only
+# Runs on: push or PR targeting the default, main, or development branches only
 ##############################################################################
   standard:
     name: "Tier 2 · standard · E2E · WP ${{ matrix.wp }} · PHP ${{ matrix.php }}"
@@ -144,10 +144,11 @@ jobs:
     if: >
       github.event_name != 'schedule' &&
       (
+        github.ref == 'refs/heads/master' ||
         github.ref == 'refs/heads/main' ||
         github.ref == 'refs/heads/development' ||
         (github.event_name == 'pull_request' &&
-          (github.base_ref == 'main' || github.base_ref == 'development'))
+          (github.base_ref == 'master' || github.base_ref == 'main' || github.base_ref == 'development'))
       )
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
           - { wp: "6.6", php: "8.2" }
           - { wp: "6.9", php: "8.2" }
           - { wp: "7.0", php: "8.2" }
+          - { wp: "7.1", php: "8.3" }
 
     env:
       TEST_BASE_URL: http://localhost:8889
@@ -241,8 +242,13 @@ jobs:
         run: |
           WP_REF="${WP_VERSION}"
           if [ "${WP_VERSION}" != "6.4" ] && ! git ls-remote --tags https://github.com/WordPress/WordPress "refs/tags/${WP_VERSION}" | grep -q .; then
-            echo "::warning::WordPress tag ${WP_VERSION} not found — falling back to trunk"
-            WP_REF="trunk"
+            WP_REF="${WP_VERSION}-branch"
+            if git ls-remote --heads https://github.com/WordPress/WordPress "refs/heads/${WP_REF}" | grep -q .; then
+              echo "::notice::WordPress tag ${WP_VERSION} not found — using release branch ${WP_REF}"
+            else
+              echo "::warning::WordPress tag and release branch for ${WP_VERSION} not found — falling back to trunk"
+              WP_REF="trunk"
+            fi
           fi
           if [ "${WP_VERSION}" = "6.4" ]; then
             printf '{"plugins":["."]}\n' > .wp-env.override.json
@@ -362,7 +368,7 @@ jobs:
         # matrix lanes run only the @compat-tagged compat specs via --grep, so
         # PRs stay within budget (the lane is the CI job, not the filename).
         # continue-on-error stays until the new lanes are reliably green; then
-        # remove it to make 6.4 + 7.0 blocking (interior lanes stay nightly).
+        # remove it to make 6.4 + the latest WP lane blocking (interior lanes stay nightly).
         # Many existing E2E tests assume local dev fixtures absent in fresh
         # wp-env — pre-existing failures, not regressions.
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,16 +241,7 @@ jobs:
         # (logged below) and run locally against the full plugin set.
         # printf (not heredoc) avoids YAML block-scalar indentation pitfalls.
         run: |
-          WP_REF="${WP_VERSION}"
-          if [ "${WP_VERSION}" != "6.4" ] && ! git ls-remote --tags https://github.com/WordPress/WordPress "refs/tags/${WP_VERSION}" | grep -q .; then
-            WP_REF="${WP_VERSION}-branch"
-            if git ls-remote --heads https://github.com/WordPress/WordPress "refs/heads/${WP_REF}" | grep -q .; then
-              echo "::notice::WordPress tag ${WP_VERSION} not found — using release branch ${WP_REF}"
-            else
-              echo "::warning::WordPress tag and release branch for ${WP_VERSION} not found — falling back to trunk"
-              WP_REF="trunk"
-            fi
-          fi
+          WP_REF=$(bash .github/scripts/resolve-wordpress-ref.sh "${WP_VERSION}")
           if [ "${WP_VERSION}" = "6.4" ]; then
             printf '{"plugins":["."]}\n' > .wp-env.override.json
           elif [ "${WP_VERSION}" = "5.6" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - Fixed: Visit tracking no longer fails with a 500 error on hosts that don't have the optional PHP `fileinfo` extension (common on managed and minimal PHP builds). When the extension is missing, the plugin now falls back to its built-in browser detector and shows a dismissible admin notice so you can ask your host to enable the extension or turn off the Browscap library.
 - Fixed: An IP-filter bug on PHP 8.1 silently added 8 extra binary bits when the tracker was handed an invalid IP, which could make rules like "ignore my IP" behave incorrectly. Filters now match correctly across all PHP versions.
 - Fixed: On PHP 8.0 and newer, clearing the Posts-list "pageviews in the last N days" interval no longer rendered an empty day count in the column header — it now falls back to 28 days exactly as it always did on PHP 7 (a PHP 8.0 comparison-semantics change had broken the fallback).
-- Tested up to WordPress 7.0. Removed an obsolete WordPress-3.3 version check that read an internal global directly.
+- Tested up to WordPress 7.1. Removed an obsolete WordPress-3.3 version check that read an internal global directly.
 
 **PHP 8.1+ readiness**
 
@@ -44,7 +44,7 @@
 - Expanded automated CI testing to cover PHP 7.4 through 8.5 (was 7.4–8.3). The PHP 7.4 lane now runs real tests on every change instead of just lint checks — which is what caught the bugs above before they could ship.
 - New regression guards make sure the same class of compatibility issues can't sneak back in.
 - Added a `CONTRIBUTING.md` documenting the test suite for contributors, plus a few small style cleanups in the tests themselves.
-- CI now boots the full WordPress version matrix (5.6 → 7.0) end-to-end on every relevant change, instead of testing a single version, so version-specific regressions surface before release. PHP 8.0/8.3/8.4 are now also blocking lanes (were nightly-only).
+- CI now boots the WordPress compatibility matrix (5.6 → 7.1) end-to-end on every relevant change, instead of testing a single version, so version-specific regressions surface before release. PHP 8.0/8.3/8.4 are now also blocking lanes (were nightly-only).
 - Added PHPStan static analysis to catch type and null-safety issues before they ship.
 - Migrated the admin JavaScript off the jQuery event shorthands that jQuery 4.0 removes (no behavior change on today's jQuery). The bundled third-party libraries remain shimmed by jQuery Migrate.
 - Removed a stray, never-loaded bundled Symfony helper file.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Text Domain: wp-slimstat
 Requires at least: 5.6
 Requires PHP: 7.4
 Recommended PHP extensions: fileinfo (required if the Browscap library is enabled)
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 5.5.0
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -124,9 +124,9 @@ An extensive knowledge base is available on our [website](https://www.wp-slimsta
 * Fix: An IP-filter bug on PHP 8.1 silently added 8 extra binary bits for invalid IPs, which could make rules like "ignore my IP" behave incorrectly. Filters now match correctly across all PHP versions.
 * PHP 8.1+ readiness: cleaned up six internal function signatures so they no longer trigger deprecation warnings in `debug.log`. These would have become fatal errors on PHP 9.0 — the plugin is now ready for that transition.
 * Fix: On PHP 8.0+, clearing the Posts-list pageviews-column interval no longer shows an empty day count — it falls back to 28 days as it did on PHP 7.
-* Tested up to WordPress 7.0; removed an obsolete WordPress-3.3 version check.
+* Tested up to WordPress 7.1; removed an obsolete WordPress-3.3 version check.
 * PHP 8.0/8.3/8.4 readiness: prepared the admin JavaScript for jQuery 4.0 (no behavior change today) and removed a stray, never-loaded bundled file.
-* Internal: Added a compatibility shim so modern PHP idioms work the same on older PHP 7.4 hosts. Expanded automated CI testing to cover PHP 7.4 through 8.5 (was 7.4–8.3) and to boot the full WordPress 5.6–7.0 matrix end-to-end; added PHPStan static analysis. The PHP 7.4 lane now runs real tests on every change instead of just lint checks. Added `CONTRIBUTING.md` and a few small style cleanups in the test suite.
+* Internal: Added a compatibility shim so modern PHP idioms work the same on older PHP 7.4 hosts. Expanded automated CI testing to cover PHP 7.4 through 8.5 (was 7.4–8.3) and to boot the WordPress 5.6–7.1 matrix end-to-end; added PHPStan static analysis. The PHP 7.4 lane now runs real tests on every change instead of just lint checks. Added `CONTRIBUTING.md` and a few small style cleanups in the test suite.
 
 = 5.4.12 - 2026-05-13 =
 * Security: Authenticated SQL injection in the chart AJAX endpoint (slimstat_fetch_chart_data) is now blocked. The `chart_data.where` parameter is validated against the trusted report registry before reaching the query layer. Reported via Patchstack (CVSS 8.5, High).

--- a/tests/e2e/compat-boot-smoke.spec.ts
+++ b/tests/e2e/compat-boot-smoke.spec.ts
@@ -1,7 +1,7 @@
 /**
  * E2E (compat matrix): admin + tracking boot smoke.
  *
- * Tagged @compat so the WordPress-version matrix lanes (5.6→7.0) can run this
+ * Tagged @compat so the WordPress-version matrix lanes (5.6→7.1) can run this
  * focused set via `--grep @compat` without executing the full suite on every
  * lane. The lane (WP core + PHP) is selected by the CI job's
  * .wp-env.override.json, not by anything in this file — one spec, N lanes.

--- a/tests/wp70-tested-up-to-test.php
+++ b/tests/wp70-tested-up-to-test.php
@@ -44,5 +44,9 @@ if (false === strpos($ci, 'WP_REF="${WP_VERSION}-branch"')) {
     fwrite(STDERR, "FAIL: CI does not resolve unreleased WordPress versions to their release branch.\n");
     exit(1);
 }
+if (false === strpos($ci, "github.base_ref == 'master'")) {
+    fwrite(STDERR, "FAIL: the compatibility job does not run for pull requests targeting master.\n");
+    exit(1);
+}
 
 echo "OK: readme.txt Tested up to = {$actual}; matching CI lane is configured\n";

--- a/tests/wp70-tested-up-to-test.php
+++ b/tests/wp70-tested-up-to-test.php
@@ -48,5 +48,9 @@ if (false === strpos($ci, "github.base_ref == 'master'")) {
     fwrite(STDERR, "FAIL: the compatibility job does not run for pull requests targeting master.\n");
     exit(1);
 }
+if (false === strpos($ci, '"${{ github.event_name }}" != "pull_request"')) {
+    fwrite(STDERR, "FAIL: pull requests are not restricted to the focused compatibility smoke.\n");
+    exit(1);
+}
 
 echo "OK: readme.txt Tested up to = {$actual}; matching CI lane is configured\n";

--- a/tests/wp70-tested-up-to-test.php
+++ b/tests/wp70-tested-up-to-test.php
@@ -4,14 +4,14 @@
  * WordPress version, and is a two-segment major.minor (the wp.org parser
  * strips any third segment).
  *
- * PINS the WP "Tested up to" readiness (Phase 6 flips $expected to '7.0' in the
- * same commit that bumps the header — RED before / green after).
+ * PINS the WordPress "Tested up to" readiness. Bump $expected in the same
+ * commit as the readme header — RED before / green after.
  */
 
 declare(strict_types=1);
 
 $plugin_root = dirname(__DIR__);
-$expected    = '7.0'; // Two-segment per the wp.org parser; bumped with readme.txt in Phase 6.
+$expected    = '7.1'; // Two-segment per the wp.org parser; bumped with readme.txt.
 
 $readme = file_get_contents($plugin_root . '/readme.txt');
 if (false === $readme) { fwrite(STDERR, "FAIL: cannot read readme.txt\n"); exit(1); }
@@ -26,10 +26,23 @@ if ($actual !== $expected) {
     fwrite(STDERR, "FAIL: readme.txt Tested up to is '{$actual}', expected '{$expected}'.\n");
     exit(1);
 }
-// Once on '7.0', enforce the wp.org two-segment form so a future 7.0.x regresses.
-if ('7.0' === $expected && !preg_match('/^\d+\.\d+$/', $actual)) {
+// Enforce the wp.org two-segment form so a future 7.1.x regresses.
+if (!preg_match('/^\d+\.\d+$/', $actual)) {
     fwrite(STDERR, "FAIL: Tested up to must be two-segment major.minor (got '{$actual}').\n");
     exit(1);
 }
 
-echo "OK: readme.txt Tested up to = {$actual}\n";
+$ci = file_get_contents($plugin_root . '/.github/workflows/ci.yml');
+if (false === $ci) { fwrite(STDERR, "FAIL: cannot read .github/workflows/ci.yml\n"); exit(1); }
+
+$lane = sprintf('- { wp: "%s", php: "8.3" }', $expected);
+if (false === strpos($ci, $lane)) {
+    fwrite(STDERR, "FAIL: CI has no WordPress {$expected} / PHP 8.3 compatibility lane.\n");
+    exit(1);
+}
+if (false === strpos($ci, 'WP_REF="${WP_VERSION}-branch"')) {
+    fwrite(STDERR, "FAIL: CI does not resolve unreleased WordPress versions to their release branch.\n");
+    exit(1);
+}
+
+echo "OK: readme.txt Tested up to = {$actual}; matching CI lane is configured\n";

--- a/tests/wp70-tested-up-to-test.php
+++ b/tests/wp70-tested-up-to-test.php
@@ -17,40 +17,101 @@ $readme = file_get_contents($plugin_root . '/readme.txt');
 if (false === $readme) { fwrite(STDERR, "FAIL: cannot read readme.txt\n"); exit(1); }
 
 if (!preg_match('/^\s*Tested up to:\s*(\S+)\s*$/m', $readme, $m)) {
-    fwrite(STDERR, "FAIL: no `Tested up to:` header in readme.txt\n");
-    exit(1);
+	fwrite(STDERR, "FAIL: no `Tested up to:` header in readme.txt\n");
+	exit(1);
 }
 $actual = $m[1];
 
 if ($actual !== $expected) {
-    fwrite(STDERR, "FAIL: readme.txt Tested up to is '{$actual}', expected '{$expected}'.\n");
-    exit(1);
+	fwrite(STDERR, "FAIL: readme.txt Tested up to is '{$actual}', expected '{$expected}'.\n");
+	exit(1);
 }
 // Enforce the wp.org two-segment form so a future 7.1.x regresses.
 if (!preg_match('/^\d+\.\d+$/', $actual)) {
-    fwrite(STDERR, "FAIL: Tested up to must be two-segment major.minor (got '{$actual}').\n");
-    exit(1);
+	fwrite(STDERR, "FAIL: Tested up to must be two-segment major.minor (got '{$actual}').\n");
+	exit(1);
 }
 
 $ci = file_get_contents($plugin_root . '/.github/workflows/ci.yml');
 if (false === $ci) { fwrite(STDERR, "FAIL: cannot read .github/workflows/ci.yml\n"); exit(1); }
 
-$lane = sprintf('- { wp: "%s", php: "8.3" }', $expected);
-if (false === strpos($ci, $lane)) {
-    fwrite(STDERR, "FAIL: CI has no WordPress {$expected} / PHP 8.3 compatibility lane.\n");
-    exit(1);
+$lane         = sprintf('- { wp: "%s", php: "8.3" }', $expected);
+$job_blocks   = preg_split('/(?=^\s{2}\w+:\s*\n\s+name:\s*"Tier)/m', $ci);
+$runtime_lane = false;
+foreach ($job_blocks as $block) {
+	if (false === strpos($block, $lane)) continue;
+	$runtime_lane = (bool) preg_match('/(?:npm\s+run\s+test:e2e|playwright\s+test)/', $block);
+	break;
 }
-if (false === strpos($ci, 'WP_REF="${WP_VERSION}-branch"')) {
-    fwrite(STDERR, "FAIL: CI does not resolve unreleased WordPress versions to their release branch.\n");
-    exit(1);
+if (!$runtime_lane) {
+	fwrite(STDERR, "FAIL: CI has no WordPress {$expected} / PHP 8.3 lane in a runtime E2E job.\n");
+	exit(1);
+}
+if (false === strpos($ci, 'resolve-wordpress-ref.sh')) {
+	fwrite(STDERR, "FAIL: CI does not use the tested WordPress reference resolver.\n");
+	exit(1);
 }
 if (false === strpos($ci, "github.base_ref == 'master'")) {
-    fwrite(STDERR, "FAIL: the compatibility job does not run for pull requests targeting master.\n");
-    exit(1);
+	fwrite(STDERR, "FAIL: the compatibility job does not run for pull requests targeting master.\n");
+	exit(1);
 }
 if (false === strpos($ci, '"${{ github.event_name }}" != "pull_request"')) {
-    fwrite(STDERR, "FAIL: pull requests are not restricted to the focused compatibility smoke.\n");
-    exit(1);
+	fwrite(STDERR, "FAIL: pull requests are not restricted to the focused compatibility smoke.\n");
+	exit(1);
 }
 
-echo "OK: readme.txt Tested up to = {$actual}; matching CI lane is configured\n";
+$resolver = $plugin_root . '/.github/scripts/resolve-wordpress-ref.sh';
+$fixtures = [
+	'tag-present' => [
+		'tag'        => 'refs/tags/7.1',
+		'branch'     => '',
+		'ref'        => '7.1',
+		'git_status' => 0,
+		'status'     => 0,
+	],
+	'branch-only' => [
+		'tag'        => '',
+		'branch'     => 'refs/heads/7.1-branch',
+		'ref'        => '7.1-branch',
+		'git_status' => 0,
+		'status'     => 0,
+	],
+	'no-ref' => [
+		'tag'        => '',
+		'branch'     => '',
+		'ref'        => 'trunk',
+		'git_status' => 0,
+		'status'     => 0,
+	],
+	'lookup-error' => [
+		'tag'        => '',
+		'branch'     => '',
+		'ref'        => '',
+		'git_status' => 28,
+		'status'     => 1,
+	],
+];
+
+foreach ($fixtures as $name => $fixture) {
+	$tmp = $plugin_root . '/tests/.wp-ref-' . bin2hex(random_bytes(8));
+	if (!mkdir($tmp, 0700)) {
+		fwrite(STDERR, "FAIL: cannot create resolver fixture directory.\n");
+		exit(1);
+	}
+	$git = "#!/usr/bin/env bash\nset -eu\nif [ " . (int) $fixture['git_status'] . " -ne 0 ]; then exit " . (int) $fixture['git_status'] . "; fi\nif [ \"\$1\" != \"ls-remote\" ]; then exit 2; fi\ncase \"\$2\" in\n  --tags) printf '%s\\n' " . escapeshellarg($fixture['tag']) . " ;;\n  --heads) printf '%s\\n' " . escapeshellarg($fixture['branch']) . " ;;\n  *) exit 2 ;;\nesac\n";
+	file_put_contents($tmp . '/git', $git);
+	chmod($tmp . '/git', 0700);
+	$command = 'GIT_COMMAND=' . escapeshellarg($tmp . '/git') . ' bash ' . escapeshellarg($resolver) . ' 7.1 2>/dev/null';
+	$output  = [];
+	$status  = 0;
+	exec($command, $output, $status);
+	unlink($tmp . '/git');
+	rmdir($tmp);
+	$ref = implode("\n", $output);
+	if ($fixture['status'] !== $status || $fixture['ref'] !== $ref) {
+		fwrite(STDERR, "FAIL: {$name} resolver fixture returned '{$ref}' (status {$status}), expected '{$fixture['ref']}' (status {$fixture['status']}).\n");
+		exit(1);
+	}
+}
+
+echo "OK: readme.txt Tested up to = {$actual}; matching runtime CI lane and resolver behavior verified\n";


### PR DESCRIPTION
## What changed
- adds a WordPress 7.1 / PHP 8.3 compatibility lane using the existing focused `@compat` admin and frontend smoke flows
- resolves prerelease versions to the matching WordPress release branch instead of unrelated trunk when no final tag exists
- updates `Tested up to` to 7.1 and extends the metadata guard to require the matching CI lane

## Why
WordPress 7.1 is currently available from the official `7.1-branch`, not a final `7.1` tag. The compatibility lane now tests that exact release line and will automatically use the tag once published.

## Focused verification
- `php tests/wp70-tested-up-to-test.php` — passes; validates the runtime E2E lane plus tag-present, branch-only, no-ref, and lookup-error resolver fixtures
- `php tests/ci-matrix-coverage-test.php` — passes
- `php -l tests/wp70-tested-up-to-test.php` — passes
- `bash -n .github/scripts/resolve-wordpress-ref.sh` — passes
- live release-ref resolver check — resolves WordPress `7.1-branch`
- `git diff --check` — passes

The existing `@compat` browser smoke covers Real-Time, Access Log, Settings, and a logged-out frontend pageview on the new WordPress 7.1 lane. I attempted the same lane locally with WordPress Playground, which identified WordPress 7.1 / PHP 8.3 but remained at HTTP 502 in this 4-CPU sandbox after a Playground worker-lock error; GitHub Actions runs the committed wp-env lane.

Closes #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end testing coverage for WordPress 7.1 on PHP 8.3.
  * Improved WordPress version detection by falling back to the release branch when a version tag is unavailable.

* **Documentation**
  * Updated compatibility and tested-version documentation to reflect WordPress 7.1.

* **Bug Fixes**
  * Improved validation of configured WordPress and PHP test lanes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->