### PR TITLE
⛔ DO NOT MERGE — census: run the 6.4 E2E lane uncapped, once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,6 +607,24 @@ jobs:
           # Override WP_ADMIN_USER / WP_ADMIN_PASS in global-setup.ts.
           WP_ADMIN_USER: admin
           WP_ADMIN_PASS: password
+          # ── CENSUS BRANCH ONLY — THIS BRANCH MUST NOT MERGE ──────────────────────────────
+          #
+          # Every CI read of this lane so far has been capped. Run 33771753689 and run
+          # 33874090767 both reported "50 failed / 5 flaky / ~470 did not run" -- the cap is
+          # maxFailures: 50, so the run STOPS at the fiftieth failure and the remaining ~470
+          # tests are never executed. That is not a census; it is the first fifty failures in
+          # scheduling order, and every count derived from it is a lower bound of unknown
+          # tightness.
+          #
+          # 0 = unbounded. Retries 0 as well: a retry masks a flake, and a census is counting
+          # flakes. Both are read by envInt(), which honours "0" because a non-empty string is
+          # truthy -- checked, not assumed.
+          #
+          # This costs one long run. It buys the denominator that WS3's quarantine ceiling is
+          # computed against, and a ceiling anchored to a capped run would lock in a number
+          # nobody can reproduce.
+          PW_MAX_FAILURES: "0"
+          PW_RETRIES: "0"
         run: |
           if [ "${WP_VERSION}" = "6.4" ]; then
             npm run test:e2e


### PR DESCRIPTION
## ⛔ DO NOT MERGE — measurement branch, one run only

This PR exists to produce **one uncapped `results.json`**. It must be closed unmerged once that artifact is read.

### Why

Every CI read of the Tier 2 E2E lane so far has been capped. Runs `33771753689` and `33874090767` both reported the same shape:

```
50 failed · 5 flaky · ~470 did not run · ~215 passed
```

That is **not a census**. `maxFailures` is 50, so the run stops at the fiftieth failure and the remaining ~470 tests never execute. "50 failed" is the first fifty failures *in scheduling order*, and every number derived from it is a lower bound of unknown tightness. The suite is **748** tests; two reads have told us about roughly a third of it.

The lane is also `continue-on-error: true`, so the job reports `success` regardless — and the GitHub API exposes the step's **conclusion**, not its **outcome**. The only way to know what happened is to read the log or the artifact.

### What this changes

One step's `env:` — `PW_MAX_FAILURES: "0"` and `PW_RETRIES: "0"`. Nothing else.

Retries 0 because a retry masks a flake and a census is counting flakes — and because it makes the run *faster*: the capped run re-ran each of its 50 failures.

### Verified before opening, not assumed

- **`envInt()` honours `"0"`.** It guards with `if (!raw) return fallback`, and `"0"` is a non-empty string, so it is truthy — the 50/1 CI defaults do not apply.
- **Tier 2 runs for a PR onto `development`** — the job's `if:` accepts `github.base_ref == 'development'`.
- **The artifact step carries `if: always()`**, so `tests/e2e/run-artifacts/results.json` survives a failing run. That file is the point: the per-spec JSON reporter is already wired, and reading the log tail instead is how one shared cause behind 38 failures was read as 38 unrelated ones.
- **No timeout can truncate it.** The only `timeout-minutes` in the workflow are two 5-minute caps on `wp-env start`; the E2E step and the job have none, so GitHub's 6h default applies. The capped lane took 29m for 276 tests.

### Why it must not merge

An uncapped, retry-free lane is right for one measurement and wrong as a standing configuration: a broken harness would run to completion instead of failing fast, and every PR would pay for it. The committed defaults (50 / 1) stay on `development`.

### What it buys

The **denominator**. The quarantine ceiling is computed against it, and a ceiling anchored to a capped run would lock in a figure nobody can reproduce.
